### PR TITLE
Make Compression Copy

### DIFF
--- a/spotflow/src/ingress/mod.rs
+++ b/spotflow/src/ingress/mod.rs
@@ -25,7 +25,7 @@ use crate::connection::ConnectionImplementation;
 use crate::{persistence, ProcessSignalsSource};
 
 /// The compression to use for sending [Messages](https://docs.spotflow.io/send-data/#message).
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Compression {
     /// Compress the message using the fastest compression algorithm settings.
     Fastest,
@@ -91,7 +91,7 @@ impl MessageContext {
 
     /// Get the compression to use for sending [Messages](https://docs.spotflow.io/send-data/#message).
     pub fn compression(&self) -> Option<Compression> {
-        self.compression.clone()
+        self.compression
     }
 
     /// Set the compression to use for sending [Messages](https://docs.spotflow.io/send-data/#message).


### PR DESCRIPTION
It is more convenient to work with a `Copy` type. Also, its lack of `Copy` made users curious as to why. The enum is small, probably just 1 byte in memory, and holds no internal state.